### PR TITLE
reconnection control & preconf verifySig flag

### DIFF
--- a/arcadia/resolutions.go
+++ b/arcadia/resolutions.go
@@ -17,6 +17,9 @@ func (cli *Arcadia) Reconnect() {
 			cli.vm.Logger().Info("receiving stop sig, stop subscribing")
 			return
 		default:
+			if time.Since(cli.lastReconnect) < 2*time.Second {
+				time.Sleep(2 * time.Second)
+			}
 			if err := cli.Subscribe(); err != nil {
 				time.Sleep(2 * time.Second)
 				cli.vm.Logger().Error("failed to resubscribe to arcadia, waiting 2s to retry", zap.Error(err))

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -166,6 +166,7 @@ func BuildBlock(
 		lbwUnits := maxUnits[fees.Bandwidth] - 50*units.KiB
 		txs, err := GetArcadiaTxs(actx, vm, r, lbwUnits, nextHght)
 		if err != nil {
+			vm.Logger().Warn("unable to get arcadia txs", zap.Error(err))
 			goto skipArcadia
 		}
 


### PR DESCRIPTION
This PR includes changes for

- Arcacida websocket reconnection rate control
- ignore signature verification if meet a epoch that we don't have record, this can happen when Arcadia fail to submit their auction bid to SEQ but still accepting chunks